### PR TITLE
Make file-level Docblock in main plugin file more consistent with other files

### DIFF
--- a/blazer-six-gist-oembed.php
+++ b/blazer-six-gist-oembed.php
@@ -1,19 +1,22 @@
 <?php
 /**
- * Plugin Name: Blazer Six Gist oEmbed
- * Plugin URI: https://github.com/bradyvercher/wp-blazer-six-gist-oembed
- * Description: Gist oEmbed and shortcode support with caching.
- * Version: 1.1.0
- * Author: Blazer Six, Inc.
- * Author URI: http://www.blazersix.com/
- * License: GPLv2 or later
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ * Blazer Six Gist oEmbed
  *
  * @package BlazerSix\GistoEmbed
  * @author Brady Vercher <brady@blazersix.com>
  * @author Gary Jones <gary@garyjones.co.uk>
  * @copyright Copyright (c) 2012, Blazer Six, Inc.
  * @license GPL-2.0+
+ *
+ * @wordpress-plugin
+ * Plugin Name: Blazer Six Gist oEmbed
+ * Plugin URI: https://github.com/bradyvercher/wp-blazer-six-gist-oembed
+ * Description: Gist oEmbed and shortcode support with caching.
+ * Version: 1.1.0
+ * Author: Blazer Six, Inc.
+ * Author URI: http://www.blazersix.com/
+ * License: GPL-2.0+
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 // Instantiate main plugin class


### PR DESCRIPTION
Add short description, followed by tags. Since free text is not allowed once a @tag has been given, we give all of the WP plugin headers under a @wordpress-plugin (follows the @vendor-type format). This may then also be parsed out by a documentation generating application, likely via a plugin.
