### PR TITLE
Issue with closing pre tag

### DIFF
--- a/class-blazer-six-gist-oembed.php
+++ b/class-blazer-six-gist-oembed.php
@@ -468,7 +468,7 @@ class Blazer_Six_Gist_oEmbed {
 
 			// Extract and cleanup the individual lines from the Gist HTML into an array for processing.
 			$lines = trim( $lines_matches[2] );
-			$lines = preg_split( '#</pre>[\s]*<pre>#', substr( $lines, 5, strlen( $lines ) - 6 ) );
+			$lines = preg_split( '#</pre>[\s]*<pre>#', substr( $lines, 5, strlen( $lines ) - 11 ) );
 
 			foreach ( $lines as $key => $line ) {
 				// Remove lines if they're not in the specified range and continue.


### PR DESCRIPTION
Before this patch, the final line of code was ending up as </pre</pre> as not enough characters were getting stripped away before exploding into individual lines.

Brady, please check this over - if you check your own rendered gists against the develop branch, you should see that the last line of the table data cell for line_data end up as:

``` html
</span></div></pre</pre></td>
```

which is clearly invalid markup.
