### PR TITLE
Add support for GitHub Updater

### DIFF
--- a/gistpress.php
+++ b/gistpress.php
@@ -9,16 +9,18 @@
  * @license   GPL-2.0+
  *
  * @wordpress-plugin
- * Plugin Name: GistPress
- * Plugin URI:  https://github.com/bradyvercher/gistpress
- * Description: Gist oEmbed and shortcode support with caching.
- * Version:     2.0.1
- * Author:      Blazer Six
- * Author URI:  http://www.blazersix.com/
- * License:     GPL-2.0+
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain: gistpress
- * Domain Path: /languages/
+ * Plugin Name:       GistPress
+ * Plugin URI:        https://github.com/bradyvercher/gistpress
+ * Description:       Gist oEmbed and shortcode support with caching.
+ * Version:           2.0.1
+ * Author:            Blazer Six
+ * Author URI:        http://www.blazersix.com/
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       gistpress
+ * Domain Path:       /languages
+ * GitHub Plugin URI: https://github.com/bradyvercher/gistpress
+ * GitHub Branch:     master
  */
 
 // Instantiate main plugin class.


### PR DESCRIPTION
Adds support for [GitHub Updater](github.com/afragen/github-updater).

The plugin URI tag points to this repo.
The branch tag is generally optional, but since we follow a git-flow process here (commit to develop, keep master as clean releases), we want to tell the updater to check that branch for changes in Version number and which archive zip to download. Once this repo changes to the Settings-> Default branch from master to develop, this tag becomes essential.

Also removed the trailing slash from the Domain Path, as WordPress trims it away anyway.
