### PR TITLE
Fix for oEmbed cache not clearing on update.

### DIFF
--- a/class-gistpress.php
+++ b/class-gistpress.php
@@ -602,7 +602,7 @@ class GistPress {
 				$attrs[] = $key . '="' . $value . '"';
 			}
 		}
-		return '[gist ' . implode( ' ', $rawattr ) . ']';
+		return '[gist ' . implode( ' ', $attrs ) . ']';
 	}
 
 	/**


### PR DESCRIPTION
Patch for issue #34

Replaced do_shortcode() with apply_filters( 'the_content' in method delete_gist_transients in class GistPress. do_shortcode() does not does not process oEmbeds, which prevented the shortcode method from being executed and clearing the cache.

Improved as per @GaryJones by using

```
do_shortcode( $GLOBALS['wp_embed']->autoembed( $post_before->post_content ) );
do_shortcode( $GLOBALS['wp_embed']->autoembed( $post_after->post_content ) );
```

Corrected `$attrs` instead of `$rawattr` as pointed out by @bradyvercher in comments on #34 
