### PR TITLE
Improved load text domain.

### DIFF
--- a/gistpress.php
+++ b/gistpress.php
@@ -45,8 +45,8 @@ $gistpress_logger = new GistPress_Log;
 function gistpress_i18n() {
 	$domain = 'gistpress';
 	$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
-	load_textdomain( $domain, WP_LANG_DIR . '/gistpress/' . $locale . '.mo' );
-	load_plugin_textdomain( $domain, false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+	load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '/' . $domain . '-' . $locale . '.mo' );
+	load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . '/languages' );
 }
 add_action( 'init', 'gistpress_i18n' );
 


### PR DESCRIPTION
Includes the required textdomain within the .mo file name.

Wraps WP_LANG_DIR in trailingslashit() to ensure two slashes aren't used.

Grabs the path to the languages folder to it better works with symlinks.
