### PR TITLE
Removing unneccessary HTML elements from Gist output

### DIFF
--- a/includes/class-gistpress.php
+++ b/includes/class-gistpress.php
@@ -420,6 +420,9 @@ class GistPress {
 		$this->debug_log( '<strong>' . __( 'Raw Key (Transient & Post Meta):', 'gistpress' ) . '</strong> ' . $raw_key, $shortcode_hash );
 		$this->debug_log( '<strong>' . __( 'Processed Output Key (Transient):', 'gistpress' ) . '</strong> ' . $transient_key, $shortcode_hash );
 
+		// Strip unneccessary elements from HTML output
+		$html = preg_replace('/^<!DOCTYPE.+?>/i', '', str_ireplace( array('<html>', '</html>', '<body>', '</body>'), '', $html));
+
 		return $html;
 	}
 


### PR DESCRIPTION
Closes issue #63 and addresses the latest comment in issue #55.

I originally had a different solution using the DOMDocument, but it was more reliable to simply parse the text directly.