### PR TITLE
Master

### DIFF
--- a/includes/class-gistpress.php
+++ b/includes/class-gistpress.php
@@ -463,6 +463,8 @@ class GistPress {
 		$html = '<?xml encoding="utf-8" ?>' . $html;
 
 		$dom = new DOMDocument();
+		// Suppress warnings for invalid tags.
+		libxml_use_internal_errors(true);
 		$dom->loadHTML( $html, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED );
 
 		$lines = $dom->getElementsByTagName( 'tr' );


### PR DESCRIPTION
Mute warnings for invalid HTML tags.

## Description
I only added `libxml_use_internal_errors(true);` right above the LoadHTML() to mute any warnings it throws.

## Motivation and Context
In its current state, the plugin fills the log with warnings like these:

PHP message: PHP Warning: DOMDocument::loadHTML(): Tag template invalid in Entity, line: 12

## How Has This Been Tested?
Didn't feel it was necessary.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
