### PR TITLE
Temporarily suspend PHP Warnings on invalid tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Temporarily suspend PHP Warnings on invalid tags when processing Gist HTML ([#81](https://github.com/bradyvercher/gistpress/issues/81))
+
 ## [v3.0.2] - 2020-01-16
 
 * Sanitized the `id` attribute passed to the `[gist]` shortcode. This fixes an XSS vulnerability that could be exploited by untrusted contributors on multi-author sites. Thanks to [@cornerpirate](https://github.com/cornerpirate) for disclosing responsibly.

--- a/includes/class-gistpress.php
+++ b/includes/class-gistpress.php
@@ -463,6 +463,10 @@ class GistPress {
 		$html = '<?xml encoding="utf-8" ?>' . $html;
 
 		$dom = new DOMDocument();
+
+		// Temporarily suppress warnings for invalid tags.
+		$previous_libxml_use_internal_errors_value = libxml_use_internal_errors( true );
+
 		$dom->loadHTML( $html, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED );
 
 		$lines = $dom->getElementsByTagName( 'tr' );
@@ -536,6 +540,9 @@ class GistPress {
 		) {
 			$html = $this->process_gist_line_numbers( $html, $args['lines'], $args['lines_start'] );
 		}
+
+		// Reset to previous value.
+		libxml_use_internal_errors( $previous_libxml_use_internal_errors_value );
 
 		return $html;
 	}


### PR DESCRIPTION
Temporarily suspend PHP Warnings on invalid tags when processing Gist HTML by setting the libxml_use_internal_errors() value to true.

The original value for libxml_use_internal_errors() is restored when the processing is complete.

props @Dan0sz

See #80

Resolves #81

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. - **Note**: I was unable to locate a  **CONTRIBUTING** document for this project.